### PR TITLE
Revert "Bump hexo-tag-bootstrap from 0.1.2 to 0.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2057,9 +2057,9 @@
       }
     },
     "hexo-tag-bootstrap": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/hexo-tag-bootstrap/-/hexo-tag-bootstrap-0.2.0.tgz",
-      "integrity": "sha512-O4IrSz3jf4dLNYN0tP/6aslXDX4MI88aFUPQjq8d72AJyOhdASEFmNgjZphS/pzaot+22Q2nr5Xd7bb2OAefxg=="
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/hexo-tag-bootstrap/download/hexo-tag-bootstrap-0.1.2.tgz",
+      "integrity": "sha1-ir1J0fS0K4RomKdMICIHz4Tc3zc="
     },
     "hexo-util": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "hexo-renderer-marked": "^2.0.0",
     "hexo-renderer-stylus": "^1.1.0",
     "hexo-server": "^1.0.0",
-    "hexo-tag-bootstrap": "^0.2.0"
+    "hexo-tag-bootstrap": "^0.1.2"
   }
 }


### PR DESCRIPTION
Reverts nekolr/nekolr.github.io#1